### PR TITLE
fix trivial typo in synopsis

### DIFF
--- a/IMAPTalk.pm
+++ b/IMAPTalk.pm
@@ -16,7 +16,7 @@ Mail::IMAPTalk - IMAP client interface with lots of features
 
   # Append message to folder
   open(my $F, 'rfc822msg.txt');
-  $IMAP->append($FolderName, $F) || dir $@;
+  $IMAP->append($FolderName, $F) || die $@;
   close($F);
 
   # Select folder and get first unseen message


### PR DESCRIPTION
Imagine the army of potential users who tried to run the synopsis, found
it failed to compile, and so stormed off to Java forever.  No more!